### PR TITLE
fix(webhook): narrow down webhook service-account rbac permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ build: local-build docker-push
 deploy-chart:
 	kubectl create ns genoa || true
 	helm upgrade genoa-webhook charts/genoa-webhook --install --namespace=genoa --set deployments.image.tag=${VERSION}
+
+uninstall-chart:
+	helm uninstall -n genoa genoa-webhook || true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Genoa-webhook
+A component of Genoa that parses git webhooks and ensures Release CR state matches git state.
+
+1. Parses webhook events from git ( github.com, github-enterprise, gitlab.com, self-hosted gitlab)
+2. Applies `Release` CR state from Git into a cluster

--- a/charts/genoa-webhook/templates/cluster-role-binding.yaml
+++ b/charts/genoa-webhook/templates/cluster-role-binding.yaml
@@ -8,5 +8,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.clusterRole }}
+  name: {{ include "genoa-webhook.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/genoa-webhook/templates/cluster-role.yaml
+++ b/charts/genoa-webhook/templates/cluster-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "genoa-webhook.fullname" $ }}
+rules:
+  - apiGroups:
+      - coveros.apps.com
+    resources:
+      - Releases
+      - Releases/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - Namespaces
+    verbs:
+      - create

--- a/charts/genoa-webhook/templates/cluster-role.yaml
+++ b/charts/genoa-webhook/templates/cluster-role.yaml
@@ -6,8 +6,8 @@ rules:
   - apiGroups:
       - coveros.apps.com
     resources:
-      - Releases
-      - Releases/status
+      - releases
+      - releases/status
     verbs:
       - create
       - delete
@@ -19,6 +19,8 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - Namespaces
+      - namespaces
     verbs:
       - create
+      - get
+      - list


### PR DESCRIPTION
webhook only need permissions to create/update/delete Release CR and create namespaces.